### PR TITLE
propagate go tool failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,11 @@ func main() {
 	}
 
 	cmd := exec.Command("go", args...)
-	out, _ := cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
 
 	fmt.Print(string(out))
+
+	if err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
goflymake currently succeeds even if go build/go test fail. This seems to cause the version of flymake on my home system to ignore the goflymake output and assume there are no errors.
