### PR TITLE
Add flycheck support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,19 @@ multi-file packages and _test.go files.  Support for os/arch specific
 
  2. Add these lines to your **.emacs** or similar:
 
- 		(add-to-list 'load-path "~/gocode/src/github.com/dougm/goflymake")
-		(require 'go-flymake)
+   * **flymake**
+
+            (add-to-list 'load-path "~/gocode/src/github.com/dougm/goflymake")
+            (require 'go-flymake)
+
+   * **flycheck**
+
+            (add-to-list 'load-path "~/gocode/src/github.com/dougm/goflymake")
+            (require 'go-flycheck)
+
 
 ### ToDo
 
 We probably shouldn't need the `goflymake` program, the `go` tool could
 be tweaked to support the flymake style of syntax checking.
 Maybe there is already a better way, but I couldn't find one.
-

--- a/go-flycheck.el
+++ b/go-flycheck.el
@@ -1,0 +1,31 @@
+;;; go-flycheck.el --- goflymake flycheck checker
+
+;; Author: Peter Vasil <mail@petervasil.net>
+
+;;; Commentary:
+;; Flycheck checker for the go programming language using goflymake tool
+;;
+;; Add the following lines to your .emacs:
+;;
+;;   (add-to-list 'load-path "$GOPATH/src/github.com/dougm/goflymake")
+;;   (require 'go-flycheck)
+
+;;; Code:
+
+(eval-when-compile
+  (require 'go-mode)
+  (require 'flycheck))
+
+(flycheck-declare-checker go-goflymake
+  "A Go syntax and style checker using the go utility.
+
+See URL `https://github.com/dougm/goflymake'."
+  :command '("goflymake" "flycheck-" source-inplace)
+  :error-patterns '(("^\\(?1:.*\\):\\(?2:[0-9]+\\): \\(?4:.*\\)$" error))
+  :modes 'go-mode)
+
+(add-to-list 'flycheck-checkers 'go-goflymake)
+
+(provide 'go-flycheck)
+
+;;; go-flycheck.el ends here

--- a/main.go
+++ b/main.go
@@ -9,12 +9,16 @@ import (
 	"strings"
 )
 
-const prefix = "flymake_"
-
 func main() {
+	prefix := "flymake_"
 	file := os.Args[len(os.Args)-1]
 	sdir := path.Dir(file)
 	base := path.Base(file)
+
+	if len(os.Args) == 3 {
+		prefix = os.Args[1]
+	}
+
 	orig := base[len(prefix):]
 
 	isTest := false


### PR DESCRIPTION
Make possible to use goflymake with flycheck by setting the prefix as
commandline argument, like this 'goflymake flycheck- <source.go>'.
