### PR TITLE
Include XTestGoFiles when compiling tests.

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 		files = append(files, pkg.CgoFiles...)
 		if isTest {
 			files = append(files, pkg.TestGoFiles...)
+			files = append(files, pkg.XTestGoFiles...)
 		}
 
 		for _, f := range files {


### PR DESCRIPTION
This resolves an issue where goflymake is used on a *_test.go source
file which is declared in a _test package and reports:

`?       command-line-arguments  [no test files]`

Tested against Go 1.2.2.
